### PR TITLE
Change maintainer to `TheCodersCorner <support@thecoderscorner.com>` only

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=LiquidCrystalIO
 version=1.4.3
 author=Arduino, Adafruit, theCodersCorner 
-maintainer=Arduino <info@arduino.cc>, TheCodersCorner <support@thecoderscorner.com>
+maintainer=TheCodersCorner <support@thecoderscorner.com>
 paragraph=Forked version LiquidCrystal to work with I2C backpacks, PCF8574, MCP23017, shift registers, ports and arduino pins. Compatible with most Hitachi HD44780 chipsets on text-based LCDs. The library works in 4 bit, 8 bit or PORT mode.
 sentence=LiquidCrystal fork for displays based on HD44780. Uses the IOAbstraction library to work with i2c, PCF8574, MCP23017, Shift registers, Arduino pins and ports interchangably.
 category=Display


### PR DESCRIPTION
Maintainer is changed from `Arduino <info@arduino.cc>, TheCodersCorner <support@thecoderscorner.com>` to `TheCodersCorner <support@thecoderscorner.com>` within the `library.properties` file. 